### PR TITLE
Fix native sqlite3 SQLi detection + http:// connection pool sizing

### DIFF
--- a/main.py
+++ b/main.py
@@ -99,6 +99,11 @@ def _sess(args):
     from tools.auth_engine import auth_from_args
     sess = auth_from_args(args)
     sess.mount("https://", _tls12_adapter())
+    # http:// otherwise falls back to the default adapter (pool_maxsize=10),
+    # which floods "Connection pool is full" warnings under multi-threaded auto.
+    _threads = getattr(args, "threads", 10) or 10
+    _pool = max(100, _threads * 4)
+    sess.mount("http://", HTTPAdapter(pool_connections=_pool, pool_maxsize=_pool))
     if "User-Agent" not in sess.headers:
         sess.headers["User-Agent"] = "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
 

--- a/tools/sql_injection.py
+++ b/tools/sql_injection.py
@@ -34,6 +34,15 @@ SQLI_ERROR_PATTERNS = [
     r"SQLite.Exception",
     r"System.Data.SQLite",
     r"SQLite3::SQLException",
+    r"sqlite3.OperationalError",
+    r"sqlite3.ProgrammingError",
+    r"sqlite3.IntegrityError",
+    r"OperationalError:.*(syntax error|no such (column|table)|unrecognized token)",
+    r"unrecognized token:",
+    r"no such column:",
+    r"no such table:",
+    r"SQLITE_ERROR",
+    r"near \"[^\"]+\": syntax error",
     r"Unclosed quotation mark",
     r"unclosed quotation mark",
     r"Unterminated string literal",
@@ -88,10 +97,12 @@ def check(url: str, param: str, sess: Optional[requests.Session] = None,
                         result["dbms"] = "Oracle"
                     elif "PostgreSQL" in p or "pg_" in p:
                         result["dbms"] = "PostgreSQL"
-                    elif "SQLite" in p:
+                    elif "SQLite" in p or "sqlite" in p or "unrecognized token" in p or "no such" in p or "SQLITE" in p:
                         result["dbms"] = "SQLite"
                     elif "SQL Server" in p or "mssql" in p:
                         result["dbms"] = "MSSQL"
+                    if not result["dbms"]:
+                        result["dbms"] = guess_dbms(r.text)
                     break
         except Exception as e:
             logger.debug("sqli error payload %s: %s", payload[:20], e)
@@ -210,7 +221,7 @@ def guess_dbms(text: str) -> Optional[str]:
         (r"mysql|MariaDB", "MySQL/MariaDB"),
         (r"postgresql|pg_|PSQLException", "PostgreSQL"),
         (r"ORA-\d{5}|oracle", "Oracle"),
-        (r"sqlite|SQLite", "SQLite"),
+        (r"sqlite|SQLite|unrecognized token|no such (column|table)|SQLITE_ERROR|near \"[^\"]+\": syntax error", "SQLite"),
         (r"mssql|sql server|OLE DB|SqlException", "MSSQL"),
     ]:
         if re.search(pat, text, re.IGNORECASE):


### PR DESCRIPTION
## What

Two small, self-contained fixes found while testing the detectors against a local Flask + sqlite3 lab.

### 1. `sql_injection.py` — detect Python-native sqlite3 errors
Error-based SQLi was a **false negative** against apps backed by Python's raw `sqlite3` module. `SQLI_ERROR_PATTERNS` only covered ORM/driver wrappers (`SQLite.Exception`, `SQLite/JDBCDriver`, `System.Data.SQLite`, `SQLite3::SQLException`), so a real injection that leaked `unrecognized token: "'"` / `near "x": syntax error` was missed.

- Added native signatures: `unrecognized token`, `no such column/table`, `near "x": syntax error`, `sqlite3.OperationalError/ProgrammingError/IntegrityError`, `SQLITE_ERROR`.
- Added `guess_dbms(resp)` fallback so `dbms` is labelled even when the matched pattern string has no DBMS keyword.
- Extended `guess_dbms` to recognise the same native formats.

**Before:** `{"vulnerable": false, ...}`  
**After:** `{"vulnerable": true, "type": "error", "dbms": "SQLite"}`

### 2. `main.py` — size the http:// connection pool
`_sess()` mounts a pool=100 TLS adapter for `https://`, but `http://` fell back to the default adapter (`pool_maxsize=10`). Under multi-threaded `auto`/`autohunt` against an http target this floods hundreds of `Connection pool is full, discarding connection` warnings.

- Mount an `HTTPAdapter` for `http://` scaled to `max(100, threads*4)`.

**Before:** hundreds of pool warnings during `auto`  
**After:** 0 warnings.

## Testing
Local Flask app (sqlite3 backend, bound to 127.0.0.1) with deliberate SQLi/XSS/SSTI/CMDi endpoints:
- `sqlcheck` now correctly flags the SQLi endpoint with `dbms: SQLite`.
- XSS / SSTI / command-injection detection unchanged (still pass).
- `auto` run: connection-pool warnings dropped from hundreds to 0.

Scope: 2 files, +18 / -2 lines. No behavioural change for MySQL/Postgres/MSSQL targets.